### PR TITLE
New blog post: restic Foundation techniques 1: CDC

### DIFF
--- a/_drafts/restic-foundation1-cdc.md
+++ b/_drafts/restic-foundation1-cdc.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: Foundation - Introducing Content Defined Chunking (CDC)
+---
+
+This post will explain Content Defined Chunking (CDC) and how it is used by restic.
+
+Backup programs need to deal with large amounts of data, saving each file again
+to the backup location when a subsequent (usually called "incremental") backup
+is created is not efficient. Over time, different strategies have emerged to
+handle data in such a case.
+
+The most basic strategy is to only save files that have changed since the last
+backup, this is where the term "incremental" backup comes from. This way,
+unmodified files are not stored again on subsequent backups. But what happens if
+just a small portion of a large file is modified? Using this strategy, the
+modified will be saved again, although most data is unchanged.
+
+A better idea is splitting a file into smaller fixed-size pieces (called
+"chunks" in the following) of e.g. 1MiB in size. When the backup program saves a
+file to the backup location, it is sufficient to save all chunks and the list of
+chunks the file consists of. These chunks can be identified for example by the
+SHA-256 hash of the content, so duplicate chunks can be detected and saved only
+once. For a file consisting of a large number of null bytes, only one chunk of
+null bytes needs to be stored.
+
+On a subsequent backup, unmodified files are not saved again because all chunks
+have already been saved before. Modified files on the other hand are split into
+chunks again, and new chunks are saved to the backup location.

--- a/_drafts/restic-foundation1-cdc.md
+++ b/_drafts/restic-foundation1-cdc.md
@@ -3,12 +3,21 @@ layout: post
 title: Foundation - Introducing Content Defined Chunking (CDC)
 ---
 
-This post will explain Content Defined Chunking (CDC) and how it is used by restic.
+This post will explain Content Defined Chunking (CDC) and how it is used by
+restic.
 
 Backup programs need to deal with large amounts of data, saving each file again
 to the backup location when a subsequent (usually called "incremental") backup
 is created is not efficient. Over time, different strategies have emerged to
 handle data in such a case.
+
+Data de-duplication can be applied twice in a backup program: Remove duplicate
+data from the same or different files within the same backup process
+(*inter-file de-duplication*), e.g. the initial backup, and between several
+backups of the same data (*inter-backup de-duplication). While the former is
+desirable to have, much more important is the latter de-duplication.
+
+### Strategies
 
 The most basic strategy is to only save files that have changed since the last
 backup, this is where the term "incremental" backup comes from. This way,
@@ -21,9 +30,235 @@ A better idea is splitting a file into smaller fixed-size pieces (called
 file to the backup location, it is sufficient to save all chunks and the list of
 chunks the file consists of. These chunks can be identified for example by the
 SHA-256 hash of the content, so duplicate chunks can be detected and saved only
-once. For a file consisting of a large number of null bytes, only one chunk of
-null bytes needs to be stored.
+once. This way, for a file consisting of a large number of null bytes, only one
+chunk of null bytes needs to be stored.
 
 On a subsequent backup, unmodified files are not saved again because all chunks
 have already been saved before. Modified files on the other hand are split into
 chunks again, and new chunks are saved to the backup location.
+
+But what happens when the user adds a byte to the beginning of the file? When
+the backup program now splits the file into fixed-sized chunks, it would (in
+most cases) end up with a list of different chunks, so it needs to save all
+chunks as new chunks to the backup location. This is not satisfactory for a
+modern backup program.
+
+### Content Defined Chunking
+
+Restic works a bit different. It also operates on chunks of data from files and
+only upload new chunks, but uses a more sophisticated approach for splitting
+files into chunks called Content Defined Chunking. This means that a file is
+split into chunks based on the content of the chunks itself, instead of always
+splitting after a fixed number of bytes.
+
+In the following, the function $$F(b_0 \dots b_{63})$$ returns a 64 bit
+[Rabin Fingerprint](https://en.wikipedia.org/wiki/Rabin_fingerprint)
+of the byte sequence in the argument. This function can be efficiently computed
+as a [rolling hash](https://en.wikipedia.org/wiki/Rolling_hash), which means
+that $$F(b_1\dots b_{64})$$ can be computed without much overhead when
+$$F(b_0\dots b_{63})$$ is already known. Restic uses 64 byte as the "window
+size" for the rolling hash.
+
+When restic saves a file, it first computes the Rabin Fingerprints for all 64
+byte sequences in the file are computed, so it starts by computing $$F(b_0\dots
+b_{63})$$, then $$F(b_1\dots b_{64})$$, then $$F(b_2\dots b_{65})$$ and so on.
+You get the idea. For each fingerprint, restic then tests if the lowest 21 bits
+are zero. If this is the case, restic found a new chunk boundary.
+
+A chunk boundary therefore depends only on the last 64 byte before the boundary,
+in other words the end of a chunk depends on the last 64 bytes of a chunk. This
+means that for our example above where the user creates a backup of a file and then
+inserts bytes at the beginning of the file, restic will find the chunk boundary
+of the first chunk (which has some additional bytes inserted in the beginning).
+The same is true for the boundaries of all chunks in the file. So on a
+subsequent backup, restic will detect that the first chunk has changed, but all
+the other chunks from the file are the same.
+
+Let's say our file consists of 4MiB data, and restic detects the following chunk
+boundaries, where "offset" is the byte offset of the last byte of the sliding
+window:
+
+| Offset | Fingerprint|
+|-------:|-----------:|
+| 577536 | `0x77db45c60d400000` |
+|1990656 | `0xc0da6ed30fe00000` |
+|2945019 | `0x309235f507600000` |
+|4194304 | End of File |
+
+The file is therefore split into four chunks. Adding 20 bytes at the beginning
+of the file still yields the same chunk boundaries, shifted by 20 bytes:
+
+| Offset | Fingerprint|
+|-------:|-----------:|
+| 577556 | `0x77db45c60d400000` |
+|1990676 | `0xc0da6ed30fe00000` |
+|2945039 | `0x309235f507600000` |
+|4194304 | End of File |
+
+When restic computes a cryptographic hash (SHA-256) over the data in each chunk,
+it detects that the first chunk has been changed (we added 20 bytes, remember?),
+but the remaining three chunks are the same. Therefore, it only needs to save
+the changed first chunk.
+
+### Examples
+
+So, let's take the things explained above to the real world, and have a bit of
+fun with restic. For the sake of simplicity, we'll save the repository location
+and the password in environment variables (`RESTIC_REPOSITORY` and
+`RESTIC_PASSWORD`) so that we don't have to type the password for every action:
+
+{% highlight console %}
+$ export RESTIC_REPOSITORY=/tmp/restic-test-repository RESTIC_PASSWORD=foo
+{% endhighlight %}
+
+Please be aware that this way the password will be contained in your shell
+history.
+
+First, initialize a new repository in a temporary location:
+
+{% highlight console %}
+$ restic init
+created restic backend 2b310bf378 at /tmp/restic-test-repository
+
+Please note that knowledge of your password is required to access
+the repository. Losing your password means that your data is
+irrecoverably lost.
+{% endhighlight %}
+
+At this point, nothing has been saved to the repository, so it is really small:
+
+{% highlight console %}
+$ du -sh $RESTIC_REPOSITORY
+8.0K	/tmp/restic-test-repository
+{% endhighlight %}
+
+Next, create a new directory called `testdata` for our test, and in there a file
+with the name `file.raw` with 100MiB of random data:
+{% highlight console %}
+$ mkdir testdata
+$ dd if=/dev/urandom of=testdata/file.raw bs=1M count=100
+100+0 records in
+100+0 records out
+104857600 bytes (105 MB) copied, 5.76985 s, 18.2 MB/s
+{% endhighlight %}
+
+And backup this directory with restic (into the repository we specified via the
+environment variable `$RESTIC_REPOSITORY` above):
+
+{% highlight console %}
+$ restic backup testdata
+scan [/home/fd0/tmp/testdata]
+scanned 1 directories, 1 files in 0:00
+[0:02] 100.00%  41.457 MiB/s  100.000 MiB / 100.000 MiB  0 / 2 it...ETA 0:00
+duration: 0:02, 44.21MiB/s
+snapshot 7452bd17 saved
+{% endhighlight %}
+
+You can see that restic created a backup with a size of 100MiB in about two
+seconds. We can verify this by checking the size of the repository again:
+
+{% highlight console %}
+$ du -sh $RESTIC_REPOSITORY
+101M	/tmp/restic-test-repository
+{% endhighlight %}
+
+You can see that the repository has pretty much the same size as the data we're
+created a backup of.
+
+Now run the backup command again:
+
+{% highlight console %}
+$ restic backup testdata
+using parent snapshot 7452bd17
+scan [/home/fd0/tmp/testdata]
+scanned 1 directories, 1 files in 0:00
+[0:00] 100.00%  0B/s  100.000 MiB / 100.000 MiB  0 / 2 items  ... ETA 0:00
+duration: 0:00, 20478.98MiB/s
+snapshot 0b870550 saved
+{% endhighlight %}
+
+Again you can see that we've instructed restic to backup 100MiB of data, but in
+this case restic was much faster and finished the job in less than a second.
+
+Looking at the repository size you can probably already guess that it is still
+about 100MiB, since we didn't really add any new data:
+
+{% highlight console %}
+$ du -sh $RESTIC_REPOSITORY
+101M	/tmp/restic-test-repository
+{% endhighlight %}
+
+When we make a copy of the file `file.raw` and backup the same repository again,
+restic recognises that all data is already known and the repository size does
+not grow at all, although the directory `testdata` now contains 200MiB of data:
+
+{% highlight console %}
+$ cp testdata/file.raw testdata/file2.raw
+
+$ du -sh testdata
+200M	testdata
+
+$ restic backup testdata
+using parent snapshot 0b870550
+scan [/home/fd0/tmp/testdata]
+scanned 1 directories, 2 files in 0:00
+[0:01] 100.00%  163.617 MiB/s  200.000 MiB / 200.000 MiB  1 / 3 ... ETA 0:00
+duration: 0:01, 129.06MiB/s
+snapshot ab8e0047 saved
+
+$ du -sh $RESTIC_REPOSITORY
+101M	/tmp/restic-test-repository
+{% endhighlight %}
+
+Now for the final demonstration we'll create a new file `file3.raw` which is a
+nasty combination of the 100MiB we've initially saved in `file.raw` so that
+`testdata` now contains about 400MiB:
+
+{% highlight console %}
+$ (echo foo; cat testdata/file.raw; echo bar; cat testdata/file.raw; echo baz) \
+  > testdata/file3.raw
+
+$ du -sh testdata
+401M	testdata
+{% endhighlight %}
+
+We'll create a new backup of the directory with restic and observe that the
+repository has grown by about 10MiB:
+
+{% highlight console %}
+$ restic backup testdata
+using parent snapshot ab8e0047
+scan [/home/fd0/tmp/testdata]
+scanned 1 directories, 3 files in 0:00
+[0:03] 100.00%  127.638 MiB/s  400.000 MiB / 400.000 MiB  2 / 4 ... ETA 0:00
+duration: 0:03, 123.73MiB/s
+snapshot a8897ae3 saved
+
+$ du -sh $RESTIC_REPOSITORY
+111M	/tmp/restic-test-repository
+{% endhighlight %}
+
+This is expected because we've created a few new chunks when creating
+`file3.raw`, e.g. the first chunk will be saved again because a few bytes (the
+string `foo\n`) has been added. But restic managed the challenge quite well.
+
+### Conclusion
+
+Content Defined Chunking is a clever idea to split large amounts of data (e.g.
+large files) into small chunks, while being able to recognize the same chunks
+again when shifted or (slightly) modified.
+
+This enables restic to de-duplicate chunks so that each chunk of data is only
+saved in (and transmitted to) the backup location once. This enables not only
+*inter-file* de-duplication, but also the more relevant *inter-backup*
+de-duplication.
+
+### References
+
+ * [The restic CDC implementation](https://github.com/restic/chunker) and
+   [API documentation](http://godoc.org/github.com/restic/chunker)
+ * Michael O. Rabin (1981): [Fingerprinting by Random Polynomials](http://www.xmailserver.org/rabin.pdf)
+ * Ross N. Williams (1993): [A Painless Guide to CRC Error Detection Algorithms](http://www.zlib.net/crc_v3.txt)
+ * Andrei Z. Broder (1993): [Some Applications of Rabin's Fingerprinting Method](http://www.xmailserver.org/rabin_apps.pdf)
+ * Shuhong Gao and Daniel Panario (1997): [Tests and Constructions of Irreducible Polynomials over Finite Fields](http://www.math.clemson.edu/~sgao/papers/GP97a.pdf)
+ * Andrew Kadatch, Bob Jenkins (2007): [Everything we know about CRC but afraid to forget](http://crcutil.googlecode.com/files/crc-doc.1.0.pdf)

--- a/_drafts/restic-foundation1-cdc.md
+++ b/_drafts/restic-foundation1-cdc.md
@@ -23,7 +23,7 @@ The most basic strategy is to only save files that have changed since the last
 backup, this is where the term "incremental" backup comes from. This way,
 unmodified files are not stored again on subsequent backups. But what happens if
 just a small portion of a large file is modified? Using this strategy, the
-modified will be saved again, although most data is unchanged.
+modified file will be saved again, although most data is unchanged.
 
 A better idea is splitting a file into smaller fixed-size pieces (called
 "chunks" in the following) of e.g. 1MiB in size. When the backup program saves a
@@ -48,7 +48,7 @@ modern backup program.
 Restic works a bit different. It also operates on chunks of data from files and
 only upload new chunks, but uses a more sophisticated approach for splitting
 files into chunks called Content Defined Chunking. This means that a file is
-split into chunks based on the content of the chunks itself, instead of always
+split into chunks based on the content of the file itself, instead of always
 splitting after a fixed number of bytes.
 
 In the following, the function $$F(b_0 \dots b_{63})$$ returns a 64 bit
@@ -56,20 +56,20 @@ In the following, the function $$F(b_0 \dots b_{63})$$ returns a 64 bit
 of the byte sequence in the argument. This function can be efficiently computed
 as a [rolling hash](https://en.wikipedia.org/wiki/Rolling_hash), which means
 that $$F(b_1\dots b_{64})$$ can be computed without much overhead when
-$$F(b_0\dots b_{63})$$ is already known. Restic uses 64 byte as the "window
+$$F(b_0\dots b_{63})$$ is already known. Restic uses 64 bytes as the "window
 size" for the rolling hash.
 
 When restic saves a file, it first computes the Rabin Fingerprints for all 64
-byte sequences in the file are computed, so it starts by computing $$F(b_0\dots
-b_{63})$$, then $$F(b_1\dots b_{64})$$, then $$F(b_2\dots b_{65})$$ and so on.
-You get the idea. For each fingerprint, restic then tests if the lowest 21 bits
-are zero. If this is the case, restic found a new chunk boundary.
+byte sequences in the file, so it starts by computing $$F(b_0\dots b_{63})$$,
+then $$F(b_1\dots b_{64})$$, then $$F(b_2\dots b_{65})$$ and so on. You get the
+idea. For each fingerprint, restic then tests if the lowest 21 bits are zero.
+If this is the case, restic found a new chunk boundary.
 
 A chunk boundary therefore depends only on the last 64 byte before the boundary,
 in other words the end of a chunk depends on the last 64 bytes of a chunk. This
 means that for our example above where the user creates a backup of a file and then
 inserts bytes at the beginning of the file, restic will find the chunk boundary
-of the first chunk (which has some additional bytes inserted in the beginning).
+of the first chunk (which has some additional bytes inserted at the beginning).
 The same is true for the boundaries of all chunks in the file. So on a
 subsequent backup, restic will detect that the first chunk has changed, but all
 the other chunks from the file are the same.
@@ -97,8 +97,8 @@ of the file still yields the same chunk boundaries, shifted by 20 bytes:
 
 When restic computes a cryptographic hash (SHA-256) over the data in each chunk,
 it detects that the first chunk has been changed (we added 20 bytes, remember?),
-but the remaining three chunks are the same. Therefore, it only needs to save
-the changed first chunk.
+but the remaining three chunks have the same hash. Therefore, it only needs to
+save the changed first chunk.
 
 ### Examples
 
@@ -114,7 +114,7 @@ $ export RESTIC_REPOSITORY=/tmp/restic-test-repository RESTIC_PASSWORD=foo
 Please be aware that this way the password will be contained in your shell
 history.
 
-First, initialize a new repository in a temporary location:
+First, initialize a new repository at a temporary location:
 
 {% highlight console %}
 $ restic init
@@ -162,8 +162,8 @@ $ du -sh $RESTIC_REPOSITORY
 101M	/tmp/restic-test-repository
 {% endhighlight %}
 
-You can see that the repository has pretty much the same size as the data we're
-created a backup of.
+You can see that the repository has pretty much the same size as the data we
+have created a backup of.
 
 Now run the backup command again:
 
@@ -179,6 +179,8 @@ snapshot 0b870550 saved
 
 Again you can see that we've instructed restic to backup 100MiB of data, but in
 this case restic was much faster and finished the job in less than a second.
+Restic would have also be able to efficiently backup a file that was renamed or
+even moved to a different directory.
 
 Looking at the repository size you can probably already guess that it is still
 about 100MiB, since we didn't really add any new data:
@@ -249,7 +251,7 @@ large files) into small chunks, while being able to recognize the same chunks
 again when shifted or (slightly) modified.
 
 This enables restic to de-duplicate chunks so that each chunk of data is only
-saved in (and transmitted to) the backup location once. This enables not only
+(transmitted to and) stored at the backup location once. This enables not only
 *inter-file* de-duplication, but also the more relevant *inter-backup*
 de-duplication.
 

--- a/_drafts/restic-foundation1-cdc.md
+++ b/_drafts/restic-foundation1-cdc.md
@@ -243,7 +243,7 @@ $ du -sh $RESTIC_REPOSITORY
 
 This is expected because we've created a few new chunks when creating
 `file3.raw`, e.g. the first chunk will be saved again because a few bytes (the
-string `foo\n`) were added. restic managed this challenge quite well and only
+string `foo\n`) were added. Restic managed this challenge quite well and only
 introduced minor overhead for storing this incremental backup.
 
 ### Conclusion

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -30,4 +30,7 @@
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml">
   <!-- Canonical URL -->
   <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
+
+  <!-- scripts -->
+  <script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 </head>

--- a/_posts/2015-09-12-restic-foundation1-cdc.md
+++ b/_posts/2015-09-12-restic-foundation1-cdc.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Foundation - Introducing Content Defined Chunking (CDC)
+date: 2015-09-12 21:27
 ---
 
 This post will explain Content Defined Chunking (CDC) and how it is used by

--- a/css/others.scss
+++ b/css/others.scss
@@ -12,3 +12,15 @@ p, li {
   text-align: justify;
   @include hyphens(auto);
 }
+
+/* override standard hyde content box width */
+.content {
+  max-width: 45rem;
+}
+
+/* override table width */
+table {
+  width: auto;
+  text-align: center;
+  margin-left: 2em;
+}


### PR DESCRIPTION
This commits add a new blog post about the first important technique restic is built on: content defined chunking (CDC). I'd like to have someone proofread the text, that's really easy when jekyll is installed:
- check out the branch locally
- run `jekyll serve --drafts`
- access the blog post at http://localhost:4000/blog/2015-09-12/restic-foundation1-cdc/ (or wherever that is on your system)

Please let me know what you think :)

ping @fw42 @heipei
