### PR TITLE
Hide Github banner on mobile, center-align subtitle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
       {{ content }}
     </div>
 
-    <a href="https://github.com/restic/restic"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+    <a href="https://github.com/restic/restic" class="desktop"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 
   </body>
 </html>

--- a/css/others.scss
+++ b/css/others.scss
@@ -8,7 +8,7 @@
   }
 }
 
-p, li {
+div.content p, div.content li {
   text-align: justify;
   @include hyphens(auto);
 }
@@ -23,4 +23,10 @@ table {
   width: auto;
   text-align: center;
   margin-left: 2em;
+}
+
+@media all and (max-width: 768px) {
+	.desktop {
+		display: none;
+	}
 }


### PR DESCRIPTION
Justify was set for p / li globally, which messed with the center-aligned header on mobile.
