### PR TITLE
Outdated doc link

### DIFF
--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ A short recorded demo of restic:
 
 To learn more about restic, checkout the user manual:
 
- * [Manual for restic 0.2.0](https://restic.readthedocs.io/en/stable/)
+ * [Manual for restic 0.3.0](https://restic.readthedocs.io/en/stable/)
  * [Manual for restic (latest develompent version)](https://restic.readthedocs.io/en/latest/)
 
 ## <a name="compatibility"></a>Compatibility


### PR DESCRIPTION
The document link's a bit outdated. Not sure if stable points to 0.3.0 on rtd, but at least 0.3.0 is on there, so I'd assume so.